### PR TITLE
Add support for Reply on Mastodon plugin

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -21,7 +21,7 @@
   {{ end }}
 
 </div>
-{{ if or (templates.Exists "partials/reply-by-email.html") (templates.Exists "partials/conversation-link.html") (templates.Exists "partials/plugin_tinylytics.html") }}
+{{ if or (templates.Exists "partials/reply-by-email.html") (templates.Exists "partials/conversation-link.html") (templates.Exists "partials/plugin_tinylytics.html") (templates.Exists "partials/reply-on-mastodon.html")}}
 <ul class="reply-buttons">
 {{ if templates.Exists "partials/plugin_tinylytics.html" }}
       <li><button class="tinylytics_kudos">Kudos</button></li>
@@ -31,6 +31,9 @@
 {{ end }}
 {{ if templates.Exists "partials/conversation-link.html" }}
   <li>{{ partial "conversation-link.html" . }}</li>
+{{ end }}
+{{ if templates.Exists "partials/reply-on-mastodon.html" }}
+  <li>{{ partial "reply-on-mastodon.html" . }}</li>
 {{ end }}
 {{ end }}
 </ul>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -143,6 +143,7 @@ nav a,
 nav a:visited,
 nav a:hover,
 a.conversation-on-mb,
+a.reply-on-mastodon,
 a.reply-by-email, a.read-more {
 	text-decoration: none;
 	padding: 5px 10px;
@@ -154,6 +155,7 @@ a.reply-by-email, a.read-more {
 
 nav a:hover,
 a.conversation-on-mb:hover,
+a.reply-on-mastodon:hover,
 a.reply-by-email:hover, a.read-more:hover {
 	background: var(--link);
 	color: var(--button-text);


### PR DESCRIPTION
I'm introducing [a new Micro.blog plugin](https://micro.blog/account/plugins/view/111), which allows people to interact with Micro.blog posts via Mastodon.

<img width="547" alt="Screenshot 2023-10-19 at 00 54 30" src="https://github.com/MattSLangford/Tiny-Theme-for-Micro.blog/assets/139272/61ce4cee-64e8-4580-a5fe-1e54912ea230">

This Pull Request adds the plugin support in Tiny Theme. And example can be [seen here](https://otavio.cc/2023/10/14/week.html).