### PR TITLE
Configurable post exclusions by category

### DIFF
--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -16,6 +16,12 @@
 <div class="full-archives h-feed">
 	<h3>Full Post List</h3>
 	{{ $list := (where .Site.Pages "Type" "post") }}
+
+  {{ $excluded_posts := where $list "Params.categories" "intersect" (slice .Site.Params.archive_excluded_categories) }}
+  {{ if gt (len $excluded_posts) 0 }}
+    {{ $list := $list | symdiff $excluded_posts}}
+  {{ end }}
+
 	{{ range $list }}
 
 	<p class="h-entry">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,13 @@
 {{ define "main" }}
 <div class="posts h-feed">
     <div class="post_list" role="main">
-        {{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") }}
+         
+        {{ $posts := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") }}
+        {{ $excluded_posts := where $posts "Params.categories" "intersect" (slice .Site.Params.index_excluded_categories) }}
+        {{ if gt (len $excluded_posts) 0 }}
+          {{ $posts := $posts | symdiff $excluded_posts}}
+        {{ end }}
+        {{ $paginator := .Paginate $posts }}
         {{ range .Paginator.Pages }}
         <div class="post-preview h-entry {{ range .Params.categories }} {{ . | urlize | lower }}{{ end }}">
           <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time> ∞</a>


### PR DESCRIPTION
* I see this come up repeatedly in the forums. Most often, folks tell me they're using this theme.
* I want to point to how to do this in case someone else wants to add this to more Micro.blog themes.

This change addresses the need by:

* Adds a check for site paramaters for `archive_excluded_categories` and `index_excluded_categories`.
* When present, returns only pages that are not on those lists.