### PR TITLE
Add a “Related” block to posts

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,3 +1,45 @@
 {
-	"paginate": 20
+	"paginate": 20,
+	"relatedCHANGEME": {
+		"includeNewer": false,
+		"indices": [{
+				"applyFilter": false,
+				"cardinalityThreshold": 0,
+				"name": "categories",
+				"pattern": "",
+				"toLower": false,
+				"type": "basic",
+				"weight": 100
+			},
+			{
+				"applyFilter": false,
+				"cardinalityThreshold": 0,
+				"name": "keywords",
+				"pattern": "",
+				"toLower": false,
+				"type": "basic",
+				"weight": 100
+			},
+			{
+				"applyFilter": false,
+				"cardinalityThreshold": 0,
+				"name": "date",
+				"pattern": "",
+				"toLower": false,
+				"type": "basic",
+				"weight": 10
+			},
+			{
+				"applyFilter": false,
+				"cardinalityThreshold": 0,
+				"name": "tags",
+				"pattern": "",
+				"toLower": false,
+				"type": "basic",
+				"weight": 80
+			}
+		],
+		"threshold": 80,
+		"toLower": false
+	}
 }

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,0 +1,21 @@
+{{ $related := .Site.RegularPages.Related . | first 5 }}
+{{ with $related }}
+  <h2 class="related-content">Related</h2>
+  <ul>
+    {{ range $i, $p := . }}
+      <li>
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        {{ with .HeadingsFiltered }}
+          <ul>
+            {{ range . }}
+              {{ $link := printf "%s#%s" $p.RelPermalink .ID | safeURL }}
+              <li>
+                <a href="{{ $link }}">{{ .Title }}</a>
+              </li>
+            {{ end }}
+          </ul>
+        {{ end }}
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -66,4 +66,8 @@
 {{ partial "microhook-after-comments.html" . }}
 {{ end }}
 
+{{ if templates.Exists "partials/related.html" }}
+{{ partial "related.html" . }}
+{{ end }}
+
 {{ end }}


### PR DESCRIPTION
This follows the examples at https://gohugo.io/content-management/related/ to add a "related content"  block to posts (see https://honeypot.net/2024/05/06/demand-that-car.html for an example). Hugo's own examples use a post's keywords, date, and tags to find related content. This adds categories into the mix to support the micro.blog way of doing things.

To enable, edit `config.json` and rename the `relatedCHANGEME` key to `related`.